### PR TITLE
Adds support for mixed-case metric names in Prometheus.

### DIFF
--- a/src/prometheus/prometheus.pest
+++ b/src/prometheus/prometheus.pest
@@ -33,8 +33,8 @@ labelname = @{ labelname_initialchar ~ labelname_char* }
 labelname_char = _{ labelname_initialchar | ASCII_DIGIT }
 labelname_initialchar = _{ ASCII_ALPHA | "_" }
 
-metricname = {ASCII_ALPHA_LOWER ~ metricnamechar* }
-metricnamechar = _{ ASCII_ALPHA_LOWER | ASCII_DIGIT | "_" }
+metricname = {ASCII_ALPHA ~ metricnamechar* }
+metricnamechar = _{ ASCII_ALPHANUMERIC | "_" }
 
 number = @{ realnumber | sign ~ (^"inf" | ^"infinity") | ^"nan" }
 timestamp = @{ realnumber }

--- a/src/prometheus/prometheus.pest
+++ b/src/prometheus/prometheus.pest
@@ -33,7 +33,7 @@ labelname = @{ labelname_initialchar ~ labelname_char* }
 labelname_char = _{ labelname_initialchar | ASCII_DIGIT }
 labelname_initialchar = _{ ASCII_ALPHA | "_" }
 
-metricname = {ASCII_ALPHA ~ metricnamechar* }
+metricname = { (ASCII_ALPHA | "_") ~ metricnamechar* }
 metricnamechar = _{ ASCII_ALPHANUMERIC | "_" }
 
 number = @{ realnumber | sign ~ (^"inf" | ^"infinity") | ^"nan" }

--- a/src/prometheus/prometheus.pest
+++ b/src/prometheus/prometheus.pest
@@ -33,8 +33,8 @@ labelname = @{ labelname_initialchar ~ labelname_char* }
 labelname_char = _{ labelname_initialchar | ASCII_DIGIT }
 labelname_initialchar = _{ ASCII_ALPHA | "_" }
 
-metricname = {ASCII_ALPHA_LOWER ~ metricnamechar* }
-metricnamechar = _{ ASCII_ALPHA_LOWER | ASCII_DIGIT | "_" }
+metricname = {ASCII_ALPHA ~ metricnamechar* }
+metricnamechar = _{ ASCII_ALPHA | ASCII_DIGIT | "_" }
 
 number = @{ realnumber | sign ~ (^"inf" | ^"infinity") | ^"nan" }
 timestamp = @{ realnumber }

--- a/src/prometheus/testdata/case_sensitive_example.txt
+++ b/src/prometheus/testdata/case_sensitive_example.txt
@@ -1,0 +1,5 @@
+# This test case was pulled from the Prometheus Node Exporter, version 1.7.0
+
+# HELP node_memory_Active_anon_bytes Memory information field Active_anon_bytes.
+# TYPE node_memory_Active_anon_bytes gauge
+node_memory_Active_anon_bytes 7.9376384e+07

--- a/src/prometheus/testdata/case_sensitive_example.txt
+++ b/src/prometheus/testdata/case_sensitive_example.txt
@@ -1,0 +1,5 @@
+# This test case was pulled from the Prometheus Node Exporter, version 1.7.0 
+
+# HELP node_memory_Active_anon_bytes Memory information field Active_anon_bytes.
+# TYPE node_memory_Active_anon_bytes gauge
+node_memory_Active_anon_bytes 7.9376384e+07

--- a/src/prometheus/testdata/case_sensitive_example.txt
+++ b/src/prometheus/testdata/case_sensitive_example.txt
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
 # This test case was pulled from the Prometheus Node Exporter, version 1.7.0
-=======
-# This test case was pulled from the Prometheus Node Exporter, version 1.7.0 
->>>>>>> 60c13aab2d10c511009ebb40c0f6e79557740686
 
 # HELP node_memory_Active_anon_bytes Memory information field Active_anon_bytes.
 # TYPE node_memory_Active_anon_bytes gauge

--- a/src/prometheus/testdata/leading_underscore.txt
+++ b/src/prometheus/testdata/leading_underscore.txt
@@ -1,0 +1,2 @@
+# TYPE _metric_with_leading_underscore gauge
+_metric_with_leading_underscore 3.14159


### PR DESCRIPTION
These metric names do exist in the wild. The test case added along with this change was pulled from the latest version of the Prometheus Node Explorer. (1.7.0)