### PR TITLE
Adds support for untyped Prometheus metrics.

### DIFF
--- a/src/prometheus/parsers.rs
+++ b/src/prometheus/parsers.rs
@@ -719,7 +719,7 @@ impl TryFrom<&str> for PrometheusType {
             "gauge" => Ok(PrometheusType::Gauge),
             "histogram" => Ok(PrometheusType::Histogram),
             "summary" => Ok(PrometheusType::Summary),
-            "unknown" => Ok(PrometheusType::Unknown),
+            "untyped" => Ok(PrometheusType::Unknown),
             _ => Err(ParseError::InvalidMetric(format!(
                 "Invalid metric type: {}",
                 value

--- a/src/prometheus/prometheus.pest
+++ b/src/prometheus/prometheus.pest
@@ -11,8 +11,9 @@ kw_counter = { "counter" }
 kw_gauge = { "gauge" }
 kw_histogram = { "histogram" }
 kw_summary = { "summary" }
+kw_untyped = { "untyped" }
 commentchar = _{ !NEWLINE ~ ANY }
-metrictype = { kw_counter | kw_gauge | kw_histogram | kw_summary }
+metrictype = { kw_counter | kw_gauge | kw_histogram | kw_summary | kw_untyped }
 COMMENT = _{ hash ~ sp ~ !(kw_help | kw_type) ~ commentchar+ ~ NEWLINE? }
 
 exposition = { SOI ~ metricset ~ end_errata? ~ EOI }

--- a/src/prometheus/testdata/untyped_example.txt
+++ b/src/prometheus/testdata/untyped_example.txt
@@ -1,0 +1,5 @@
+# This test case was pulled from the Prometheus Node Exporter, version 1.7.0 
+
+# HELP node_vmstat_pgfault /proc/vmstat information field pgfault.
+# TYPE node_vmstat_pgfault untyped
+node_vmstat_pgfault 1.131748065e+09


### PR DESCRIPTION
When the type of a metric is not known, the Prometheus exposition format uses the type "untyped". This differs from the OpenMetrics specification, which uses "unknown". This can be seen in the official Prometheus text parser: https://github.com/prometheus/prometheus/blob/e2b9cfeeeb1efbe299c386226622a5064f23f377/model/textparse/promparse.go#L317

This change also adds a test case drawn from the latest version of the Prometheus Node Exporter. (1.7.0)