### PR TITLE
Prometheus metric names may contain uppercase

### DIFF
--- a/src/prometheus/prometheus.pest
+++ b/src/prometheus/prometheus.pest
@@ -33,8 +33,8 @@ labelname = @{ labelname_initialchar ~ labelname_char* }
 labelname_char = _{ labelname_initialchar | ASCII_DIGIT }
 labelname_initialchar = _{ ASCII_ALPHA | "_" }
 
-metricname = {ASCII_ALPHA_LOWER ~ metricnamechar* }
-metricnamechar = _{ ASCII_ALPHA_LOWER | ASCII_DIGIT | "_" }
+metricname = {ASCII_ALPHA ~ metricnamechar* }
+metricnamechar = _{ ASCII_ALPHANUMERIC | "_" }
 
 number = @{ realnumber | sign ~ (^"inf" | ^"infinity") | ^"nan" }
 timestamp = @{ realnumber }


### PR DESCRIPTION
> Metric names may contain ASCII letters, digits, underscores, and colons. It must match the regex [a-zA-Z_:][a-zA-Z0-9_:]*.
https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels

Fixes: #7 