### PR TITLE
Fix tests for openmetrics parser, add more negative tests

### DIFF
--- a/src/openmetrics/testdata/example.txt
+++ b/src/openmetrics/testdata/example.txt
@@ -1,0 +1,8 @@
+# TYPE go_goroutines gauge
+# HELP go_goroutines Number of goroutines that currently exist.
+go_goroutines 69
+# TYPE process_cpu_seconds counter
+# UNIT process_cpu_seconds seconds
+# HELP process_cpu_seconds Total user and system CPU time spent in seconds.
+process_cpu_seconds_total 4.20072246e+06
+# EOF

--- a/src/openmetrics/tests.rs
+++ b/src/openmetrics/tests.rs
@@ -1,67 +1,36 @@
-use serde::Deserialize;
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::fs;
 
-#[derive(Deserialize, Debug)]
-struct TestMeta {
-    #[serde(alias = "shouldParse")]
-    should_parse: bool,
-}
+use crate::ParseError;
+use super::parsers::parse_openmetrics;
 
-fn read_child_file(parent: &Path, filename: &str) -> String {
-    let mut child_path = PathBuf::new();
-    child_path.push(parent);
-    child_path.push(filename);
-
-    assert!(child_path.exists());
-    assert!(child_path.is_file());
-
-    let child_str = fs::read_to_string(child_path);
-    assert!(child_str.is_ok());
-
-    child_str.unwrap()
+/// Test the parser on cases that parse successfully.
+#[test]
+fn test_openmetrics_parser() {
+    for file in fs::read_dir("./src/openmetrics/testdata").unwrap() {
+        let file = file.unwrap();
+        let path = file.path();
+        if path.extension().unwrap() == "txt" {
+            let child_str = fs::read_to_string(&path).unwrap();
+            let result = parse_openmetrics(&child_str);
+            assert!(result.is_ok(), "failed to parse {}: {}", path.display(), result.err().unwrap());
+        }
+    }
 }
 
 #[test]
-fn run_openmetrics_validation() {
-    let tests = fs::read_dir("./OpenMetrics/tests/testdata/parsers");
-    assert!(tests.is_ok());
-
-    for test in tests.unwrap() {
-        assert!(test.is_ok());
-        let test = test.unwrap();
-        let path = test.path();
-        let test_name = path.file_name().unwrap();
-
-        assert!(path.is_dir());
-
-        let metrics_str = read_child_file(&path, "metrics");
-        let test_meta_str = read_child_file(&path, "test.json");
-
-        let meta = serde_json::from_str::<TestMeta>(&test_meta_str);
-        assert!(meta.is_ok());
-        let meta = meta.unwrap();
-
-        println!("\n[TEST{:?}]", test_name);
-        let parsed = crate::openmetrics::parse_openmetrics(&metrics_str);
-        let metrics_str = metrics_str.replace(" ", ".").replace("\t", "->");
-
-        if meta.should_parse {
-            assert!(
-                parsed.is_ok(),
-                "\n{}\n Test should parse, but didn't ({:?})",
-                metrics_str,
-                parsed
-            );
-        } else {
-            assert!(
-                parsed.is_err(),
-                "\n{}\n Test shouldn't parse, but did ({:?})",
-                metrics_str,
-                parsed
-            );
+fn test_openmetrics_parser_enforce_no_leading_digit_metric_name() {
+    let result = parse_openmetrics(r#"
+# HELP 1_leading_integer_not_allowed A summary of the RPC duration in seconds.
+# TYPE 1_leading_integer_not_allowed summary
+1_leading_integer_not_allowed{quantile="0.01"} 3102
+    "#);
+    dbg!(&result);
+    match result {
+        Err(ParseError::ParseError(x)) => {
+            assert!(x.contains("expected metricfamily"));
         }
-    }
+        _ => {
+            panic!("Expected ParseError::ParseError");
+        }
+    };
 }

--- a/src/prometheus/tests.rs
+++ b/src/prometheus/tests.rs
@@ -1,5 +1,6 @@
 use std::fs;
 
+use crate::ParseError;
 use super::parsers::parse_prometheus;
 
 #[test]
@@ -13,4 +14,22 @@ fn test_prometheus_parser() {
             assert!(result.is_ok(), "failed to parse {}: {}", path.display(), result.err().unwrap());
         }
     }
+}
+
+#[test]
+fn test_prometheus_parser_enforce_no_leading_digit_metric_name() {
+    let result = parse_prometheus(r#"
+# HELP 1_leading_integer_not_allowed A summary of the RPC duration in seconds.
+# TYPE 1_leading_integer_not_allowed summary
+1_leading_integer_not_allowed{quantile="0.01"} 3102
+    "#);
+    dbg!(&result);
+    match result {
+        Err(ParseError::ParseError(x)) => {
+            assert!(x.contains("expected metricname"));
+        }
+        _ => {
+            panic!("Expected ParseError::ParseError");
+        }
+    };
 }

--- a/src/public/tests.rs
+++ b/src/public/tests.rs
@@ -1,4 +1,3 @@
-use crate::prometheus::parse_prometheus;
 
 #[test]
 fn test_label_sets() {
@@ -67,6 +66,7 @@ fn test_label_sets() {
 
 #[test]
 fn test_render() {
+    use crate::prometheus::parse_prometheus;
     let test_str = include_str!("../prometheus/testdata/upstream_example.txt");
     let exposition = parse_prometheus(test_str).unwrap();
     let exposition_str = exposition.to_string();


### PR DESCRIPTION
Thought this might be useful.  `cargo test` passed for me locally now, and I added a couple of extra tests for cases where parsing should fail as examples.